### PR TITLE
Allow commands in the middle of messages

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,7 +1,7 @@
 export const CODE = /`{3}(ts|js)\r?\n([\s\S]*)`{3}/i;
-export const HELP = /^\?h[ea]lp$/i;
-export const EVAL = /^\?eval/i;
-export const DESTRUCT = /^\?SELFDESTRUCT/i;
+export const HELP = /\?h[ea]lp$/i;
+export const EVAL = /\?eval/i;
+export const DESTRUCT = /\?SELFDESTRUCT/i;
 export const OWNER = "230054162719571979";
 
 export const THIRTY_SECS = 30 * 1_000;


### PR DESCRIPTION
Among other things, this lets you use `?eval` with Disord's reply/mention/quote features, which default to putting mentions at the beginning of the message before `?eval`